### PR TITLE
Hopefully fixed log4j exploit(I am not the best build system wizard)for 1.17 fabric

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,12 +19,29 @@ repositories {
 }
 
 minecraft {
-	accessWidener =  file("src/main/resources/betterbiomeblend.accesswidener")
+	accessWidenerPath =  file("src/main/resources/betterbiomeblend.accesswidener")
+}
+
+configurations.all {
+  resolutionStrategy.eachDependency { details ->
+    if (details.requested.group == 'org.apache.logging.log4j') {
+      details.useVersion '2.16.0'
+      details.because 'zero-day-exploits suck'
+    }
+  }
 }
 
 dependencies {
+	constraints{
+		implementation("org.apache.logging.log4j:log4j-core") {
+			version {
+				strictly("[2.16, 3[")
+				prefer("2.16.0")
+			}
+		}
+	}
 	// To change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	yarn "com.mojang:yarn:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 	// for more information about repositories.
 }
 
-minecraft {
+loom {
 	accessWidenerPath =  file("src/main/resources/betterbiomeblend.accesswidener")
 }
 
@@ -41,7 +41,7 @@ dependencies {
 		}
 	}
 	// To change the versions see the gradle.properties file
-	yarn "com.mojang:yarn:${project.minecraft_version}"
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 


### PR DESCRIPTION
<pre>I thought I fixed it until I did "gradlew dependencies" so I naturally did
more fixes 'till gradlew dependencies gave me more optimistic results.
credits:
https://stackoverflow.com/questions/70317385/gradle-java-how-to-upgrade-log4j-safely
https://blog.gradle.org/log4j-vulnerability</pre>